### PR TITLE
ruby 1.9に対応させるためのマジックコメントを追加

### DIFF
--- a/lib/holiday_jp.rb
+++ b/lib/holiday_jp.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'date'
 require 'ostruct'
 


### PR DESCRIPTION
ruby1.9環境でマルチバイトのエラーがでたため、マジックコメントを追加しました。
よろしくお願いします。
