### PR TITLE
Shorten holiday definitions

### DIFF
--- a/lib/holiday_jp.rb
+++ b/lib/holiday_jp.rb
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
-require 'date'
-require 'ostruct'
+require 'holiday_jp/holiday'
 require 'holiday_jp/holidays'
 
 module HolidayJp
-  DAYNAMES_JA = %w(日 月 火 水 木 金 土)
-
   # == Between date
   # === Example:
   #  >> holidays = HolidayJp.between(Date.new(2010, 9, 14), Date.new(2010, 9, 21))

--- a/lib/holiday_jp/holiday.rb
+++ b/lib/holiday_jp/holiday.rb
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+require 'date'
+module HolidayJp
+  class Holiday
+    WDAY_NAMES = %w(日 月 火 水 木 金 土)
+
+    EN_HOLIDAY_NAMES = {
+      "元日" => "New Year's Day",
+      "成人の日" => "Coming of Age Day",
+      "建国記念の日" => "National Foundation Day",
+      "春分の日" => "Vernal Equinox Day",
+      "憲法記念日" => "Constitution Memorial Day",
+      "みどりの日" => "Greenery Day",
+      "こどもの日" => "Children's Day",
+      "海の日" => "Marine Day",
+      "敬老の日" => "Respect for the Aged Day",
+      "秋分の日" => "Autumnal Equinox Day",
+      "体育の日" => "Health and Sports Day",
+      "文化の日" => "National Culture Day",
+      "勤労感謝の日" => "Labor Thanksgiving Day",
+      "天皇誕生日" => "Emperor's Birthday",
+      "昭和の日" => "Showa Day",
+      "振替休日" => "Holiday in lieu",
+      "国民の休日" => "Citizen's Holiday",
+      "即位礼正殿の儀" => "The Ceremony of the Enthronement of His Majesty th Emperor (at the Seiden)",
+      "昭和天皇の大喪の礼" => "The Funeral Ceremony of Emperor Showa.",
+      "皇太子徳仁親王の結婚の儀" => "The Rite of Wedding of HIH Crown Prince Naruhito"
+    }
+
+    attr_reader :date, :name
+    def initialize(date, name)
+      @date = parse_date(date)
+      @name = name
+    end
+
+    def name_en
+      EN_HOLIDAY_NAMES[name]
+    end
+
+    def wday_name
+      WDAY_NAMES[date.wday]
+    end
+    alias :week :wday_name
+
+    def parse_date(date)
+      begin
+        Date.parse(date)
+      rescue ArgumentError
+        raise ArgumentError, "invalid date on :#{date}, #{name}"
+      end
+    end
+  end
+end

--- a/lib/holiday_jp/holidays.rb
+++ b/lib/holiday_jp/holidays.rb
@@ -1,7710 +1,1290 @@
 # -*- coding: utf-8 -*-
 module HolidayJp
-  base_data = [
-    {
-      :date    => Date.new(1970, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1970, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1970, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1970, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1970, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1970, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1970, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1970, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1970, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1970, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1970, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1970, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1971, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1971, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1971, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1971, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1971, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1971, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1971, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1971, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1971, 9, 24),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1971, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1971, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1971, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1972, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1972, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1972, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1972, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1972, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1972, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1972, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1972, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1972, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1972, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1972, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1972, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1973, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1973, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1973, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1973, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1973, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1973, 4, 30),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1973, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1973, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1973, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1973, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1973, 9, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1973, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1973, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1973, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1974, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1974, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1974, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1974, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1974, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1974, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1974, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1974, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1974, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1974, 9, 16),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1974, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1974, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1974, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1974, 11, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1974, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1975, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1975, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1975, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1975, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1975, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1975, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1975, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1975, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1975, 9, 24),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1975, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1975, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1975, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1975, 11, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1976, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1976, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1976, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1976, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1976, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1976, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1976, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1976, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1976, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1976, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1976, 10, 11),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1976, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1976, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1977, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1977, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1977, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1977, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1977, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1977, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1977, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1977, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1977, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1977, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1977, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1977, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1978, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1978, 1, 2),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1978, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1978, 1, 16),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1978, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1978, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1978, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1978, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1978, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1978, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1978, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1978, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1978, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1978, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1979, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1979, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1979, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1979, 2, 12),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1979, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1979, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1979, 4, 30),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1979, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1979, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1979, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1979, 9, 24),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1979, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1979, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1979, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1980, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1980, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1980, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1980, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1980, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1980, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1980, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1980, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1980, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1980, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1980, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1980, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1980, 11, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1981, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1981, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1981, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1981, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1981, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1981, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1981, 5, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1981, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1981, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1981, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1981, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1981, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1981, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1982, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1982, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1982, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1982, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1982, 3, 22),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1982, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1982, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1982, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1982, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1982, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1982, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1982, 10, 11),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1982, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1982, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1983, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1983, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1983, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1983, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1983, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1983, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1983, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1983, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1983, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1983, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1983, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1983, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1984, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1984, 1, 2),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1984, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1984, 1, 16),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1984, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1984, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1984, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1984, 4, 30),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1984, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1984, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1984, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1984, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1984, 9, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1984, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1984, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1984, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1985, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1985, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1985, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1985, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1985, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1985, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1985, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1985, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1985, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1985, 9, 16),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1985, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1985, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1985, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1985, 11, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1985, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1986, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1986, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1986, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1986, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1986, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1986, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1986, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1986, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1986, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1986, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1986, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1986, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1986, 11, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1987, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1987, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1987, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1987, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1987, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1987, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1987, 5, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1987, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1987, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1987, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1987, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1987, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1987, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1988, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1988, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1988, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1988, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1988, 3, 21),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1988, 4, 29),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1988, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1988, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1988, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1988, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1988, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1988, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1988, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1988, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1989, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1989, 1, 2),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1989, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1989, 1, 16),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1989, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1989, 2, 24),
-      :name    => "昭和天皇の大喪の礼",
-      :name_en => "The Funeral Ceremony of Emperor Showa.",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1989, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1989, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1989, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1989, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1989, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1989, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1989, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1989, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1989, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1989, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1989, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1990, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1990, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1990, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1990, 2, 12),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1990, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1990, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1990, 4, 30),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1990, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1990, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1990, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1990, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1990, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1990, 9, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1990, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1990, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1990, 11, 12),
-      :name    => "即位礼正殿の儀",
-      :name_en => "The Ceremony of the Enthronement of His Majesty the Emperor (at the Seiden)",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1990, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1990, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1990, 12, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1991, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1991, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1991, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1991, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1991, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1991, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1991, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1991, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1991, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1991, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1991, 9, 16),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1991, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1991, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1991, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1991, 11, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1991, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1991, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1992, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1992, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1992, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1992, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1992, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1992, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1992, 5, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1992, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1992, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1992, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1992, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1992, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1992, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1992, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1993, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1993, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1993, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1993, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1993, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1993, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1993, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1993, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1993, 6, 9),
-      :name    => "皇太子徳仁親王の結婚の儀",
-      :name_en => "The Rite of Wedding of HIH Crown Prince Naruhito",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1993, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1993, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1993, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1993, 10, 11),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1993, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1993, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1993, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1994, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1994, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1994, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1994, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1994, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1994, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1994, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1994, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1994, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1994, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1994, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1994, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1994, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1994, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1995, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1995, 1, 2),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1995, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1995, 1, 16),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1995, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1995, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1995, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1995, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1995, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1995, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1995, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1995, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1995, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1995, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1995, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1995, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1996, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1996, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1996, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1996, 2, 12),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1996, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1996, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1996, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1996, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1996, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1996, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1996, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1996, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1996, 9, 16),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1996, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1996, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1996, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1996, 11, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1996, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1996, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1997, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1997, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1997, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1997, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1997, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1997, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1997, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1997, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1997, 7, 21),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1997, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1997, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1997, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1997, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1997, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1997, 11, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1997, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1998, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1998, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1998, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1998, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1998, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1998, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1998, 5, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1998, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1998, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1998, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1998, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1998, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(1998, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1998, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1998, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1999, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1999, 1, 15),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(1999, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1999, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1999, 3, 22),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1999, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1999, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1999, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1999, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1999, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1999, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1999, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(1999, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(1999, 10, 11),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(1999, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(1999, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(1999, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2000, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2000, 1, 10),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2000, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2000, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2000, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2000, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2000, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2000, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2000, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2000, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2000, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2000, 10, 9),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2000, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2000, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2000, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2001, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2001, 1, 8),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2001, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2001, 2, 12),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2001, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2001, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2001, 4, 30),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2001, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2001, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2001, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2001, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2001, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2001, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2001, 9, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2001, 10, 8),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2001, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2001, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2001, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2001, 12, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2002, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2002, 1, 14),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2002, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2002, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2002, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2002, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2002, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2002, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2002, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2002, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2002, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2002, 9, 16),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2002, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2002, 10, 14),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2002, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2002, 11, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2002, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2002, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2003, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2003, 1, 13),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2003, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2003, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2003, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2003, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2003, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2003, 7, 21),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2003, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2003, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2003, 10, 13),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2003, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2003, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2003, 11, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2003, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2004, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2004, 1, 12),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2004, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2004, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2004, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2004, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2004, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2004, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2004, 7, 19),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2004, 9, 20),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2004, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2004, 10, 11),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2004, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2004, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2004, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2005, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2005, 1, 10),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2005, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2005, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2005, 3, 21),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2005, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2005, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2005, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2005, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2005, 7, 18),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2005, 9, 19),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2005, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2005, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2005, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2005, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2005, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2006, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2006, 1, 2),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2006, 1, 9),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2006, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2006, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2006, 4, 29),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2006, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2006, 5, 4),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2006, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2006, 7, 17),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2006, 9, 18),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2006, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2006, 10, 9),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2006, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2006, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2006, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2007, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2007, 1, 8),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2007, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2007, 2, 12),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2007, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2007, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2007, 4, 30),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2007, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2007, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2007, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2007, 7, 16),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2007, 9, 17),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2007, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2007, 9, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2007, 10, 8),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2007, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2007, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2007, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2007, 12, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2008, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2008, 1, 14),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2008, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2008, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2008, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2008, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2008, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2008, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2008, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2008, 7, 21),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2008, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2008, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2008, 10, 13),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2008, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2008, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2008, 11, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2008, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2009, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2009, 1, 12),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2009, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2009, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2009, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2009, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2009, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2009, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2009, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2009, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2009, 9, 21),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2009, 9, 22),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2009, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2009, 10, 12),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2009, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2009, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2009, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2010, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2010, 1, 11),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2010, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2010, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2010, 3, 22),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2010, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2010, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2010, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2010, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2010, 7, 19),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2010, 9, 20),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2010, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2010, 10, 11),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2010, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2010, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2010, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2011, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2011, 1, 10),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2011, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2011, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2011, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2011, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2011, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2011, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2011, 7, 18),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2011, 9, 19),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2011, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2011, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2011, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2011, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2011, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2012, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2012, 1, 2),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2012, 1, 9),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2012, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2012, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2012, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2012, 4, 30),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2012, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2012, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2012, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2012, 7, 16),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2012, 9, 17),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2012, 9, 22),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2012, 10, 8),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2012, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2012, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2012, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2012, 12, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2013, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2013, 1, 14),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2013, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2013, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2013, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2013, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2013, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2013, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2013, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2013, 7, 15),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2013, 9, 16),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2013, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2013, 10, 14),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2013, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2013, 11, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2013, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2013, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2014, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2014, 1, 13),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2014, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2014, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2014, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2014, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2014, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2014, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2014, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2014, 7, 21),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2014, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2014, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2014, 10, 13),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2014, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2014, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2014, 11, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2014, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2015, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2015, 1, 12),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2015, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2015, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2015, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2015, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2015, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2015, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2015, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2015, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2015, 9, 21),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2015, 9, 22),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2015, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2015, 10, 12),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2015, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2015, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2015, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2016, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2016, 1, 11),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2016, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2016, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2016, 3, 21),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2016, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2016, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2016, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2016, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2016, 7, 18),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2016, 9, 19),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2016, 9, 22),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2016, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2016, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2016, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2016, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2017, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2017, 1, 2),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2017, 1, 9),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2017, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2017, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2017, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2017, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2017, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2017, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2017, 7, 17),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2017, 9, 18),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2017, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2017, 10, 9),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2017, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2017, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2017, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2018, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2018, 1, 8),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2018, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2018, 2, 12),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2018, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2018, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2018, 4, 30),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2018, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2018, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2018, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2018, 7, 16),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2018, 9, 17),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2018, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2018, 9, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2018, 10, 8),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2018, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2018, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2018, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2018, 12, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2019, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2019, 1, 14),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2019, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2019, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2019, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2019, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2019, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2019, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2019, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2019, 7, 15),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2019, 9, 16),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2019, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2019, 10, 14),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2019, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2019, 11, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2019, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2019, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2020, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2020, 1, 13),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2020, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2020, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2020, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2020, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2020, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2020, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2020, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2020, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2020, 9, 21),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2020, 9, 22),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2020, 10, 12),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2020, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2020, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2020, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2021, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2021, 1, 11),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2021, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2021, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2021, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2021, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2021, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2021, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2021, 7, 19),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2021, 9, 20),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2021, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2021, 10, 11),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2021, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2021, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2021, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2022, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2022, 1, 10),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2022, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2022, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2022, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2022, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2022, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2022, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2022, 7, 18),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2022, 9, 19),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2022, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2022, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2022, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2022, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2022, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2023, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2023, 1, 2),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2023, 1, 9),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2023, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2023, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2023, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2023, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2023, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2023, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2023, 7, 17),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2023, 9, 18),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2023, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2023, 10, 9),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2023, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2023, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2023, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2024, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2024, 1, 8),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2024, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2024, 2, 12),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2024, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2024, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2024, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2024, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2024, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2024, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2024, 7, 15),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2024, 9, 16),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2024, 9, 22),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2024, 9, 23),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2024, 10, 14),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2024, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2024, 11, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2024, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2024, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2025, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2025, 1, 13),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2025, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2025, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2025, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2025, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2025, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2025, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2025, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2025, 7, 21),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2025, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2025, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2025, 10, 13),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2025, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2025, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2025, 11, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2025, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2026, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2026, 1, 12),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2026, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2026, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2026, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2026, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2026, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2026, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2026, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2026, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2026, 9, 21),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2026, 9, 22),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2026, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2026, 10, 12),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2026, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2026, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2026, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2027, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2027, 1, 11),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2027, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2027, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2027, 3, 22),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2027, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2027, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2027, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2027, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2027, 7, 19),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2027, 9, 20),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2027, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2027, 10, 11),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2027, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2027, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2027, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2028, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2028, 1, 10),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2028, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2028, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2028, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2028, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2028, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2028, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2028, 7, 17),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2028, 9, 18),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2028, 9, 22),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2028, 10, 9),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2028, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2028, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2028, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2029, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2029, 1, 8),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2029, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2029, 2, 12),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2029, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2029, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2029, 4, 30),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2029, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2029, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2029, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2029, 7, 16),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2029, 9, 17),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2029, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2029, 9, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2029, 10, 8),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2029, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2029, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2029, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2029, 12, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2030, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2030, 1, 14),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2030, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2030, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2030, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2030, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2030, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2030, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2030, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2030, 7, 15),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2030, 9, 16),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2030, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2030, 10, 14),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2030, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2030, 11, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2030, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2030, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2031, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2031, 1, 13),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2031, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2031, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2031, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2031, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2031, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2031, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2031, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2031, 7, 21),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2031, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2031, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2031, 10, 13),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2031, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2031, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2031, 11, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2031, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2032, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2032, 1, 12),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2032, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2032, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2032, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2032, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2032, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2032, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2032, 7, 19),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2032, 9, 20),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2032, 9, 21),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2032, 9, 22),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2032, 10, 11),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2032, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2032, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2032, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2033, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2033, 1, 10),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2033, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2033, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2033, 3, 21),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2033, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2033, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2033, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2033, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2033, 7, 18),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2033, 9, 19),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2033, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2033, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2033, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2033, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2033, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2034, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2034, 1, 2),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2034, 1, 9),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2034, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2034, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2034, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2034, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2034, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2034, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2034, 7, 17),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2034, 9, 18),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2034, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2034, 10, 9),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2034, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2034, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2034, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2035, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2035, 1, 8),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2035, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2035, 2, 12),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2035, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2035, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2035, 4, 30),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2035, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2035, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2035, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2035, 7, 16),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2035, 9, 17),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2035, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2035, 9, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2035, 10, 8),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2035, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2035, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2035, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2035, 12, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2036, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2036, 1, 14),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2036, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2036, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2036, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2036, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2036, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2036, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2036, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2036, 7, 21),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2036, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2036, 9, 22),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2036, 10, 13),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2036, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2036, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2036, 11, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2036, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2037, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2037, 1, 12),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2037, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2037, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2037, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2037, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2037, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2037, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2037, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2037, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2037, 9, 21),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2037, 9, 22),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2037, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2037, 10, 12),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2037, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2037, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2037, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2038, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2038, 1, 11),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2038, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2038, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2038, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2038, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2038, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2038, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2038, 7, 19),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2038, 9, 20),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2038, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2038, 10, 11),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2038, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2038, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2038, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2039, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2039, 1, 10),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2039, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2039, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2039, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2039, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2039, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2039, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2039, 7, 18),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2039, 9, 19),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2039, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2039, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2039, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2039, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2039, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2040, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2040, 1, 2),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2040, 1, 9),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2040, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2040, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2040, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2040, 4, 30),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2040, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2040, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2040, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2040, 7, 16),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2040, 9, 17),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2040, 9, 22),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2040, 10, 8),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2040, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2040, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2040, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2040, 12, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2041, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2041, 1, 14),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2041, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2041, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2041, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2041, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2041, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2041, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2041, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2041, 7, 15),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2041, 9, 16),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2041, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2041, 10, 14),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2041, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2041, 11, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2041, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2041, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2042, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2042, 1, 13),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2042, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2042, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2042, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2042, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2042, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2042, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2042, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2042, 7, 21),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2042, 9, 15),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2042, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2042, 10, 13),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2042, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2042, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2042, 11, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2042, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2043, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2043, 1, 12),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2043, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2043, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2043, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2043, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2043, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2043, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2043, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2043, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2043, 9, 21),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2043, 9, 22),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2043, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2043, 10, 12),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2043, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2043, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2043, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2044, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2044, 1, 11),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2044, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2044, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2044, 3, 21),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2044, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2044, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2044, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2044, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2044, 7, 18),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2044, 9, 19),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2044, 9, 22),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2044, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2044, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2044, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2044, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2045, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2045, 1, 2),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2045, 1, 9),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2045, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2045, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2045, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2045, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2045, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2045, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2045, 7, 17),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2045, 9, 18),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2045, 9, 22),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2045, 10, 9),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2045, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2045, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2045, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2046, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2046, 1, 8),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2046, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2046, 2, 12),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2046, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2046, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2046, 4, 30),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2046, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2046, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2046, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2046, 7, 16),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2046, 9, 17),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2046, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2046, 9, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2046, 10, 8),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2046, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2046, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2046, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2046, 12, 24),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2047, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2047, 1, 14),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2047, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2047, 3, 21),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2047, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2047, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2047, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2047, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2047, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2047, 7, 15),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2047, 9, 16),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2047, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2047, 10, 14),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2047, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2047, 11, 4),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2047, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2047, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2048, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2048, 1, 13),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2048, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2048, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2048, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2048, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2048, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2048, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2048, 5, 6),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2048, 7, 20),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2048, 9, 21),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2048, 9, 22),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2048, 10, 12),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2048, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2048, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2048, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2049, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2049, 1, 11),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2049, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2049, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2049, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2049, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2049, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2049, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2049, 7, 19),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2049, 9, 20),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2049, 9, 21),
-      :name    => "国民の休日",
-      :name_en => "Citizen's Holiday",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2049, 9, 22),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2049, 10, 11),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2049, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2049, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2049, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2050, 1, 1),
-      :name    => "元日",
-      :name_en => "New Year's Day",
-      :week    => "土"
-    },
-    {
-      :date    => Date.new(2050, 1, 10),
-      :name    => "成人の日",
-      :name_en => "Coming of Age Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2050, 2, 11),
-      :name    => "建国記念の日",
-      :name_en => "National Foundation Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2050, 3, 20),
-      :name    => "春分の日",
-      :name_en => "Vernal Equinox Day",
-      :week    => "日"
-    },
-    {
-      :date    => Date.new(2050, 3, 21),
-      :name    => "振替休日",
-      :name_en => "Holiday in lieu",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2050, 4, 29),
-      :name    => "昭和の日",
-      :name_en => "Showa Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2050, 5, 3),
-      :name    => "憲法記念日",
-      :name_en => "Constitution Memorial Day",
-      :week    => "火"
-    },
-    {
-      :date    => Date.new(2050, 5, 4),
-      :name    => "みどりの日",
-      :name_en => "Greenery Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2050, 5, 5),
-      :name    => "こどもの日",
-      :name_en => "Children's Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2050, 7, 18),
-      :name    => "海の日",
-      :name_en => "Marine Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2050, 9, 19),
-      :name    => "敬老の日",
-      :name_en => "Respect for the Aged Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2050, 9, 23),
-      :name    => "秋分の日",
-      :name_en => "Autumnal Equinox Day",
-      :week    => "金"
-    },
-    {
-      :date    => Date.new(2050, 10, 10),
-      :name    => "体育の日",
-      :name_en => "Health and Sports Day",
-      :week    => "月"
-    },
-    {
-      :date    => Date.new(2050, 11, 3),
-      :name    => "文化の日",
-      :name_en => "National Culture Day",
-      :week    => "木"
-    },
-    {
-      :date    => Date.new(2050, 11, 23),
-      :name    => "勤労感謝の日",
-      :name_en => "Labor Thanksgiving Day",
-      :week    => "水"
-    },
-    {
-      :date    => Date.new(2050, 12, 23),
-      :name    => "天皇誕生日",
-      :name_en => "Emperor's Birthday",
-      :week    => "金"
-    },
+  base_holidays = [
+    ["1970-01-01","元日"],
+    ["1970-01-15","成人の日"],
+    ["1970-02-11","建国記念の日"],
+    ["1970-03-21","春分の日"],
+    ["1970-04-29","天皇誕生日"],
+    ["1970-05-03","憲法記念日"],
+    ["1970-05-05","こどもの日"],
+    ["1970-09-15","敬老の日"],
+    ["1970-09-23","秋分の日"],
+    ["1970-10-10","体育の日"],
+    ["1970-11-03","文化の日"],
+    ["1970-11-23","勤労感謝の日"],
+    ["1971-01-01","元日"],
+    ["1971-01-15","成人の日"],
+    ["1971-02-11","建国記念の日"],
+    ["1971-03-21","春分の日"],
+    ["1971-04-29","天皇誕生日"],
+    ["1971-05-03","憲法記念日"],
+    ["1971-05-05","こどもの日"],
+    ["1971-09-15","敬老の日"],
+    ["1971-09-24","秋分の日"],
+    ["1971-10-10","体育の日"],
+    ["1971-11-03","文化の日"],
+    ["1971-11-23","勤労感謝の日"],
+    ["1972-01-01","元日"],
+    ["1972-01-15","成人の日"],
+    ["1972-02-11","建国記念の日"],
+    ["1972-03-20","春分の日"],
+    ["1972-04-29","天皇誕生日"],
+    ["1972-05-03","憲法記念日"],
+    ["1972-05-05","こどもの日"],
+    ["1972-09-15","敬老の日"],
+    ["1972-09-23","秋分の日"],
+    ["1972-10-10","体育の日"],
+    ["1972-11-03","文化の日"],
+    ["1972-11-23","勤労感謝の日"],
+    ["1973-01-01","元日"],
+    ["1973-01-15","成人の日"],
+    ["1973-02-11","建国記念の日"],
+    ["1973-03-21","春分の日"],
+    ["1973-04-29","天皇誕生日"],
+    ["1973-04-30","振替休日"],
+    ["1973-05-03","憲法記念日"],
+    ["1973-05-05","こどもの日"],
+    ["1973-09-15","敬老の日"],
+    ["1973-09-23","秋分の日"],
+    ["1973-09-24","振替休日"],
+    ["1973-10-10","体育の日"],
+    ["1973-11-03","文化の日"],
+    ["1973-11-23","勤労感謝の日"],
+    ["1974-01-01","元日"],
+    ["1974-01-15","成人の日"],
+    ["1974-02-11","建国記念の日"],
+    ["1974-03-21","春分の日"],
+    ["1974-04-29","天皇誕生日"],
+    ["1974-05-03","憲法記念日"],
+    ["1974-05-05","こどもの日"],
+    ["1974-05-06","振替休日"],
+    ["1974-09-15","敬老の日"],
+    ["1974-09-16","振替休日"],
+    ["1974-09-23","秋分の日"],
+    ["1974-10-10","体育の日"],
+    ["1974-11-03","文化の日"],
+    ["1974-11-04","振替休日"],
+    ["1974-11-23","勤労感謝の日"],
+    ["1975-01-01","元日"],
+    ["1975-01-15","成人の日"],
+    ["1975-02-11","建国記念の日"],
+    ["1975-03-21","春分の日"],
+    ["1975-04-29","天皇誕生日"],
+    ["1975-05-03","憲法記念日"],
+    ["1975-05-05","こどもの日"],
+    ["1975-09-15","敬老の日"],
+    ["1975-09-24","秋分の日"],
+    ["1975-10-10","体育の日"],
+    ["1975-11-03","文化の日"],
+    ["1975-11-23","勤労感謝の日"],
+    ["1975-11-24","振替休日"],
+    ["1976-01-01","元日"],
+    ["1976-01-15","成人の日"],
+    ["1976-02-11","建国記念の日"],
+    ["1976-03-20","春分の日"],
+    ["1976-04-29","天皇誕生日"],
+    ["1976-05-03","憲法記念日"],
+    ["1976-05-05","こどもの日"],
+    ["1976-09-15","敬老の日"],
+    ["1976-09-23","秋分の日"],
+    ["1976-10-10","体育の日"],
+    ["1976-10-11","振替休日"],
+    ["1976-11-03","文化の日"],
+    ["1976-11-23","勤労感謝の日"],
+    ["1977-01-01","元日"],
+    ["1977-01-15","成人の日"],
+    ["1977-02-11","建国記念の日"],
+    ["1977-03-21","春分の日"],
+    ["1977-04-29","天皇誕生日"],
+    ["1977-05-03","憲法記念日"],
+    ["1977-05-05","こどもの日"],
+    ["1977-09-15","敬老の日"],
+    ["1977-09-23","秋分の日"],
+    ["1977-10-10","体育の日"],
+    ["1977-11-03","文化の日"],
+    ["1977-11-23","勤労感謝の日"],
+    ["1978-01-01","元日"],
+    ["1978-01-02","振替休日"],
+    ["1978-01-15","成人の日"],
+    ["1978-01-16","振替休日"],
+    ["1978-02-11","建国記念の日"],
+    ["1978-03-21","春分の日"],
+    ["1978-04-29","天皇誕生日"],
+    ["1978-05-03","憲法記念日"],
+    ["1978-05-05","こどもの日"],
+    ["1978-09-15","敬老の日"],
+    ["1978-09-23","秋分の日"],
+    ["1978-10-10","体育の日"],
+    ["1978-11-03","文化の日"],
+    ["1978-11-23","勤労感謝の日"],
+    ["1979-01-01","元日"],
+    ["1979-01-15","成人の日"],
+    ["1979-02-11","建国記念の日"],
+    ["1979-02-12","振替休日"],
+    ["1979-03-21","春分の日"],
+    ["1979-04-29","天皇誕生日"],
+    ["1979-04-30","振替休日"],
+    ["1979-05-03","憲法記念日"],
+    ["1979-05-05","こどもの日"],
+    ["1979-09-15","敬老の日"],
+    ["1979-09-24","秋分の日"],
+    ["1979-10-10","体育の日"],
+    ["1979-11-03","文化の日"],
+    ["1979-11-23","勤労感謝の日"],
+    ["1980-01-01","元日"],
+    ["1980-01-15","成人の日"],
+    ["1980-02-11","建国記念の日"],
+    ["1980-03-20","春分の日"],
+    ["1980-04-29","天皇誕生日"],
+    ["1980-05-03","憲法記念日"],
+    ["1980-05-05","こどもの日"],
+    ["1980-09-15","敬老の日"],
+    ["1980-09-23","秋分の日"],
+    ["1980-10-10","体育の日"],
+    ["1980-11-03","文化の日"],
+    ["1980-11-23","勤労感謝の日"],
+    ["1980-11-24","振替休日"],
+    ["1981-01-01","元日"],
+    ["1981-01-15","成人の日"],
+    ["1981-02-11","建国記念の日"],
+    ["1981-03-21","春分の日"],
+    ["1981-04-29","天皇誕生日"],
+    ["1981-05-03","憲法記念日"],
+    ["1981-05-04","振替休日"],
+    ["1981-05-05","こどもの日"],
+    ["1981-09-15","敬老の日"],
+    ["1981-09-23","秋分の日"],
+    ["1981-10-10","体育の日"],
+    ["1981-11-03","文化の日"],
+    ["1981-11-23","勤労感謝の日"],
+    ["1982-01-01","元日"],
+    ["1982-01-15","成人の日"],
+    ["1982-02-11","建国記念の日"],
+    ["1982-03-21","春分の日"],
+    ["1982-03-22","振替休日"],
+    ["1982-04-29","天皇誕生日"],
+    ["1982-05-03","憲法記念日"],
+    ["1982-05-05","こどもの日"],
+    ["1982-09-15","敬老の日"],
+    ["1982-09-23","秋分の日"],
+    ["1982-10-10","体育の日"],
+    ["1982-10-11","振替休日"],
+    ["1982-11-03","文化の日"],
+    ["1982-11-23","勤労感謝の日"],
+    ["1983-01-01","元日"],
+    ["1983-01-15","成人の日"],
+    ["1983-02-11","建国記念の日"],
+    ["1983-03-21","春分の日"],
+    ["1983-04-29","天皇誕生日"],
+    ["1983-05-03","憲法記念日"],
+    ["1983-05-05","こどもの日"],
+    ["1983-09-15","敬老の日"],
+    ["1983-09-23","秋分の日"],
+    ["1983-10-10","体育の日"],
+    ["1983-11-03","文化の日"],
+    ["1983-11-23","勤労感謝の日"],
+    ["1984-01-01","元日"],
+    ["1984-01-02","振替休日"],
+    ["1984-01-15","成人の日"],
+    ["1984-01-16","振替休日"],
+    ["1984-02-11","建国記念の日"],
+    ["1984-03-20","春分の日"],
+    ["1984-04-29","天皇誕生日"],
+    ["1984-04-30","振替休日"],
+    ["1984-05-03","憲法記念日"],
+    ["1984-05-05","こどもの日"],
+    ["1984-09-15","敬老の日"],
+    ["1984-09-23","秋分の日"],
+    ["1984-09-24","振替休日"],
+    ["1984-10-10","体育の日"],
+    ["1984-11-03","文化の日"],
+    ["1984-11-23","勤労感謝の日"],
+    ["1985-01-01","元日"],
+    ["1985-01-15","成人の日"],
+    ["1985-02-11","建国記念の日"],
+    ["1985-03-21","春分の日"],
+    ["1985-04-29","天皇誕生日"],
+    ["1985-05-03","憲法記念日"],
+    ["1985-05-05","こどもの日"],
+    ["1985-05-06","振替休日"],
+    ["1985-09-15","敬老の日"],
+    ["1985-09-16","振替休日"],
+    ["1985-09-23","秋分の日"],
+    ["1985-10-10","体育の日"],
+    ["1985-11-03","文化の日"],
+    ["1985-11-04","振替休日"],
+    ["1985-11-23","勤労感謝の日"],
+    ["1986-01-01","元日"],
+    ["1986-01-15","成人の日"],
+    ["1986-02-11","建国記念の日"],
+    ["1986-03-21","春分の日"],
+    ["1986-04-29","天皇誕生日"],
+    ["1986-05-03","憲法記念日"],
+    ["1986-05-05","こどもの日"],
+    ["1986-09-15","敬老の日"],
+    ["1986-09-23","秋分の日"],
+    ["1986-10-10","体育の日"],
+    ["1986-11-03","文化の日"],
+    ["1986-11-23","勤労感謝の日"],
+    ["1986-11-24","振替休日"],
+    ["1987-01-01","元日"],
+    ["1987-01-15","成人の日"],
+    ["1987-02-11","建国記念の日"],
+    ["1987-03-21","春分の日"],
+    ["1987-04-29","天皇誕生日"],
+    ["1987-05-03","憲法記念日"],
+    ["1987-05-04","振替休日"],
+    ["1987-05-05","こどもの日"],
+    ["1987-09-15","敬老の日"],
+    ["1987-09-23","秋分の日"],
+    ["1987-10-10","体育の日"],
+    ["1987-11-03","文化の日"],
+    ["1987-11-23","勤労感謝の日"],
+    ["1988-01-01","元日"],
+    ["1988-01-15","成人の日"],
+    ["1988-02-11","建国記念の日"],
+    ["1988-03-20","春分の日"],
+    ["1988-03-21","振替休日"],
+    ["1988-04-29","天皇誕生日"],
+    ["1988-05-03","憲法記念日"],
+    ["1988-05-04","国民の休日"],
+    ["1988-05-05","こどもの日"],
+    ["1988-09-15","敬老の日"],
+    ["1988-09-23","秋分の日"],
+    ["1988-10-10","体育の日"],
+    ["1988-11-03","文化の日"],
+    ["1988-11-23","勤労感謝の日"],
+    ["1989-01-01","元日"],
+    ["1989-01-02","振替休日"],
+    ["1989-01-15","成人の日"],
+    ["1989-01-16","振替休日"],
+    ["1989-02-11","建国記念の日"],
+    ["1989-02-24","昭和天皇の大喪の礼"],
+    ["1989-03-21","春分の日"],
+    ["1989-04-29","みどりの日"],
+    ["1989-05-03","憲法記念日"],
+    ["1989-05-04","国民の休日"],
+    ["1989-05-05","こどもの日"],
+    ["1989-09-15","敬老の日"],
+    ["1989-09-23","秋分の日"],
+    ["1989-10-10","体育の日"],
+    ["1989-11-03","文化の日"],
+    ["1989-11-23","勤労感謝の日"],
+    ["1989-12-23","天皇誕生日"],
+    ["1990-01-01","元日"],
+    ["1990-01-15","成人の日"],
+    ["1990-02-11","建国記念の日"],
+    ["1990-02-12","振替休日"],
+    ["1990-03-21","春分の日"],
+    ["1990-04-29","みどりの日"],
+    ["1990-04-30","振替休日"],
+    ["1990-05-03","憲法記念日"],
+    ["1990-05-04","国民の休日"],
+    ["1990-05-05","こどもの日"],
+    ["1990-09-15","敬老の日"],
+    ["1990-09-23","秋分の日"],
+    ["1990-09-24","振替休日"],
+    ["1990-10-10","体育の日"],
+    ["1990-11-03","文化の日"],
+    ["1990-11-12","即位礼正殿の儀"],
+    ["1990-11-23","勤労感謝の日"],
+    ["1990-12-23","天皇誕生日"],
+    ["1990-12-24","振替休日"],
+    ["1991-01-01","元日"],
+    ["1991-01-15","成人の日"],
+    ["1991-02-11","建国記念の日"],
+    ["1991-03-21","春分の日"],
+    ["1991-04-29","みどりの日"],
+    ["1991-05-03","憲法記念日"],
+    ["1991-05-04","国民の休日"],
+    ["1991-05-05","こどもの日"],
+    ["1991-05-06","振替休日"],
+    ["1991-09-15","敬老の日"],
+    ["1991-09-16","振替休日"],
+    ["1991-09-23","秋分の日"],
+    ["1991-10-10","体育の日"],
+    ["1991-11-03","文化の日"],
+    ["1991-11-04","振替休日"],
+    ["1991-11-23","勤労感謝の日"],
+    ["1991-12-23","天皇誕生日"],
+    ["1992-01-01","元日"],
+    ["1992-01-15","成人の日"],
+    ["1992-02-11","建国記念の日"],
+    ["1992-03-20","春分の日"],
+    ["1992-04-29","みどりの日"],
+    ["1992-05-03","憲法記念日"],
+    ["1992-05-04","振替休日"],
+    ["1992-05-05","こどもの日"],
+    ["1992-09-15","敬老の日"],
+    ["1992-09-23","秋分の日"],
+    ["1992-10-10","体育の日"],
+    ["1992-11-03","文化の日"],
+    ["1992-11-23","勤労感謝の日"],
+    ["1992-12-23","天皇誕生日"],
+    ["1993-01-01","元日"],
+    ["1993-01-15","成人の日"],
+    ["1993-02-11","建国記念の日"],
+    ["1993-03-20","春分の日"],
+    ["1993-04-29","みどりの日"],
+    ["1993-05-03","憲法記念日"],
+    ["1993-05-04","国民の休日"],
+    ["1993-05-05","こどもの日"],
+    ["1993-06-09","皇太子徳仁親王の結婚の儀"],
+    ["1993-09-05","敬老の日"],
+    ["1993-09-23","秋分の日"],
+    ["1993-10-10","体育の日"],
+    ["1993-10-11","振替休日"],
+    ["1993-11-03","文化の日"],
+    ["1993-11-23","勤労感謝の日"],
+    ["1993-12-23","天皇誕生日"],
+    ["1994-01-01","元日"],
+    ["1994-01-15","成人の日"],
+    ["1994-02-11","建国記念の日"],
+    ["1994-03-21","春分の日"],
+    ["1994-04-29","みどりの日"],
+    ["1994-05-03","憲法記念日"],
+    ["1994-05-04","国民の休日"],
+    ["1994-05-05","こどもの日"],
+    ["1994-09-15","敬老の日"],
+    ["1994-09-23","秋分の日"],
+    ["1994-10-10","体育の日"],
+    ["1994-11-03","文化の日"],
+    ["1994-11-23","勤労感謝の日"],
+    ["1994-12-23","天皇誕生日"],
+    ["1995-01-01","元日"],
+    ["1995-01-02","振替休日"],
+    ["1995-01-15","成人の日"],
+    ["1995-01-16","振替休日"],
+    ["1995-02-11","建国記念の日"],
+    ["1995-03-21","春分の日"],
+    ["1995-04-29","みどりの日"],
+    ["1995-05-03","憲法記念日"],
+    ["1995-05-04","国民の休日"],
+    ["1995-05-05","こどもの日"],
+    ["1995-09-15","敬老の日"],
+    ["1995-09-23","秋分の日"],
+    ["1995-10-10","体育の日"],
+    ["1995-11-03","文化の日"],
+    ["1995-11-23","勤労感謝の日"],
+    ["1995-12-23","天皇誕生日"],
+    ["1996-01-01","元日"],
+    ["1996-01-15","成人の日"],
+    ["1996-02-11","建国記念の日"],
+    ["1996-02-12","振替休日"],
+    ["1996-03-20","春分の日"],
+    ["1996-04-29","みどりの日"],
+    ["1996-05-03","憲法記念日"],
+    ["1996-05-04","国民の休日"],
+    ["1996-05-05","こどもの日"],
+    ["1996-05-06","振替休日"],
+    ["1996-07-20","海の日"],
+    ["1996-09-15","敬老の日"],
+    ["1996-09-16","振替休日"],
+    ["1996-09-23","秋分の日"],
+    ["1996-10-10","体育の日"],
+    ["1996-11-03","文化の日"],
+    ["1996-11-04","振替休日"],
+    ["1996-11-23","勤労感謝の日"],
+    ["1996-12-23","天皇誕生日"],
+    ["1997-01-01","元日"],
+    ["1997-01-15","成人の日"],
+    ["1997-02-11","建国記念の日"],
+    ["1997-03-20","春分の日"],
+    ["1997-04-29","みどりの日"],
+    ["1997-05-03","憲法記念日"],
+    ["1997-05-05","こどもの日"],
+    ["1997-07-20","海の日"],
+    ["1997-07-21","振替休日"],
+    ["1997-09-15","敬老の日"],
+    ["1997-09-23","秋分の日"],
+    ["1997-10-10","体育の日"],
+    ["1997-11-03","文化の日"],
+    ["1997-11-23","勤労感謝の日"],
+    ["1997-11-24","振替休日"],
+    ["1997-12-23","天皇誕生日"],
+    ["1998-01-01","元日"],
+    ["1998-01-15","成人の日"],
+    ["1998-02-11","建国記念の日"],
+    ["1998-03-21","春分の日"],
+    ["1998-04-29","みどりの日"],
+    ["1998-05-03","憲法記念日"],
+    ["1998-05-04","振替休日"],
+    ["1998-05-05","こどもの日"],
+    ["1998-07-20","海の日"],
+    ["1998-09-15","敬老の日"],
+    ["1998-09-23","秋分の日"],
+    ["1998-10-10","体育の日"],
+    ["1998-11-03","文化の日"],
+    ["1998-11-23","勤労感謝の日"],
+    ["1998-12-23","天皇誕生日"],
+    ["1999-01-01","元日"],
+    ["1999-01-15","成人の日"],
+    ["1999-02-11","建国記念の日"],
+    ["1999-03-21","春分の日"],
+    ["1999-03-22","振替休日"],
+    ["1999-04-29","みどりの日"],
+    ["1999-05-03","憲法記念日"],
+    ["1999-05-04","国民の休日"],
+    ["1999-05-05","こどもの日"],
+    ["1999-07-20","海の日"],
+    ["1999-09-15","敬老の日"],
+    ["1999-09-23","秋分の日"],
+    ["1999-10-10","体育の日"],
+    ["1999-10-11","振替休日"],
+    ["1999-11-03","文化の日"],
+    ["1999-11-23","勤労感謝の日"],
+    ["1999-12-23","天皇誕生日"],
+    ["2000-01-01","元日"],
+    ["2000-01-10","成人の日"],
+    ["2000-02-11","建国記念の日"],
+    ["2000-03-20","春分の日"],
+    ["2000-04-29","みどりの日"],
+    ["2000-05-03","憲法記念日"],
+    ["2000-05-04","国民の休日"],
+    ["2000-05-05","こどもの日"],
+    ["2000-07-20","海の日"],
+    ["2000-09-15","敬老の日"],
+    ["2000-09-23","秋分の日"],
+    ["2000-10-09","体育の日"],
+    ["2000-11-03","文化の日"],
+    ["2000-11-23","勤労感謝の日"],
+    ["2000-12-23","天皇誕生日"],
+    ["2001-01-01","元日"],
+    ["2001-01-08","成人の日"],
+    ["2001-02-11","建国記念の日"],
+    ["2001-02-12","振替休日"],
+    ["2001-03-20","春分の日"],
+    ["2001-04-29","みどりの日"],
+    ["2001-04-30","振替休日"],
+    ["2001-05-03","憲法記念日"],
+    ["2001-05-04","国民の休日"],
+    ["2001-05-05","こどもの日"],
+    ["2001-07-20","海の日"],
+    ["2001-09-15","敬老の日"],
+    ["2001-09-23","秋分の日"],
+    ["2001-09-24","振替休日"],
+    ["2001-10-08","体育の日"],
+    ["2001-11-03","文化の日"],
+    ["2001-11-23","勤労感謝の日"],
+    ["2001-12-23","天皇誕生日"],
+    ["2001-12-24","振替休日"],
+    ["2002-01-01","元日"],
+    ["2002-01-14","成人の日"],
+    ["2002-02-11","建国記念の日"],
+    ["2002-03-21","春分の日"],
+    ["2002-04-29","みどりの日"],
+    ["2002-05-03","憲法記念日"],
+    ["2002-05-04","国民の休日"],
+    ["2002-05-05","こどもの日"],
+    ["2002-05-06","振替休日"],
+    ["2002-07-20","海の日"],
+    ["2002-09-15","敬老の日"],
+    ["2002-09-16","振替休日"],
+    ["2002-09-23","秋分の日"],
+    ["2002-10-14","体育の日"],
+    ["2002-11-03","文化の日"],
+    ["2002-11-04","振替休日"],
+    ["2002-11-23","勤労感謝の日"],
+    ["2002-12-23","天皇誕生日"],
+    ["2003-01-01","元日"],
+    ["2003-01-13","成人の日"],
+    ["2003-02-11","建国記念の日"],
+    ["2003-03-21","春分の日"],
+    ["2003-04-29","みどりの日"],
+    ["2003-05-03","憲法記念日"],
+    ["2003-05-05","こどもの日"],
+    ["2003-07-21","海の日"],
+    ["2003-09-15","敬老の日"],
+    ["2003-09-23","秋分の日"],
+    ["2003-10-13","体育の日"],
+    ["2003-11-03","文化の日"],
+    ["2003-11-23","勤労感謝の日"],
+    ["2003-11-24","振替休日"],
+    ["2003-12-23","天皇誕生日"],
+    ["2004-01-01","元日"],
+    ["2004-01-12","成人の日"],
+    ["2004-02-11","建国記念の日"],
+    ["2004-03-20","春分の日"],
+    ["2004-04-29","みどりの日"],
+    ["2004-05-03","憲法記念日"],
+    ["2004-05-04","国民の休日"],
+    ["2004-05-05","こどもの日"],
+    ["2004-07-19","海の日"],
+    ["2004-09-20","敬老の日"],
+    ["2004-09-23","秋分の日"],
+    ["2004-10-11","体育の日"],
+    ["2004-11-03","文化の日"],
+    ["2004-11-23","勤労感謝の日"],
+    ["2004-12-23","天皇誕生日"],
+    ["2005-01-01","元日"],
+    ["2005-01-10","成人の日"],
+    ["2005-02-11","建国記念の日"],
+    ["2005-03-20","春分の日"],
+    ["2005-03-21","振替休日"],
+    ["2005-04-29","みどりの日"],
+    ["2005-05-03","憲法記念日"],
+    ["2005-05-04","国民の休日"],
+    ["2005-05-05","こどもの日"],
+    ["2005-07-18","海の日"],
+    ["2005-09-19","敬老の日"],
+    ["2005-09-23","秋分の日"],
+    ["2005-10-10","体育の日"],
+    ["2005-11-03","文化の日"],
+    ["2005-11-23","勤労感謝の日"],
+    ["2005-12-23","天皇誕生日"],
+    ["2006-01-01","元日"],
+    ["2006-01-02","振替休日"],
+    ["2006-01-09","成人の日"],
+    ["2006-02-11","建国記念の日"],
+    ["2006-03-21","春分の日"],
+    ["2006-04-29","みどりの日"],
+    ["2006-05-03","憲法記念日"],
+    ["2006-05-04","国民の休日"],
+    ["2006-05-05","こどもの日"],
+    ["2006-07-17","海の日"],
+    ["2006-09-18","敬老の日"],
+    ["2006-09-23","秋分の日"],
+    ["2006-10-09","体育の日"],
+    ["2006-11-03","文化の日"],
+    ["2006-11-23","勤労感謝の日"],
+    ["2006-12-23","天皇誕生日"],
+    ["2007-01-01","元日"],
+    ["2007-01-08","成人の日"],
+    ["2007-02-11","建国記念の日"],
+    ["2007-02-12","振替休日"],
+    ["2007-03-21","春分の日"],
+    ["2007-04-29","昭和の日"],
+    ["2007-04-30","振替休日"],
+    ["2007-05-03","憲法記念日"],
+    ["2007-05-04","みどりの日"],
+    ["2007-05-05","こどもの日"],
+    ["2007-07-16","海の日"],
+    ["2007-09-17","敬老の日"],
+    ["2007-09-23","秋分の日"],
+    ["2007-09-24","振替休日"],
+    ["2007-10-08","体育の日"],
+    ["2007-11-03","文化の日"],
+    ["2007-11-23","勤労感謝の日"],
+    ["2007-12-23","天皇誕生日"],
+    ["2007-12-24","振替休日"],
+    ["2008-01-01","元日"],
+    ["2008-01-14","成人の日"],
+    ["2008-02-11","建国記念の日"],
+    ["2008-03-20","春分の日"],
+    ["2008-04-29","昭和の日"],
+    ["2008-05-03","憲法記念日"],
+    ["2008-05-04","みどりの日"],
+    ["2008-05-05","こどもの日"],
+    ["2008-05-06","振替休日"],
+    ["2008-07-21","海の日"],
+    ["2008-09-15","敬老の日"],
+    ["2008-09-23","秋分の日"],
+    ["2008-10-13","体育の日"],
+    ["2008-11-03","文化の日"],
+    ["2008-11-23","勤労感謝の日"],
+    ["2008-11-24","振替休日"],
+    ["2008-12-23","天皇誕生日"],
+    ["2009-01-01","元日"],
+    ["2009-01-12","成人の日"],
+    ["2009-02-11","建国記念の日"],
+    ["2009-03-20","春分の日"],
+    ["2009-04-29","昭和の日"],
+    ["2009-05-03","憲法記念日"],
+    ["2009-05-04","みどりの日"],
+    ["2009-05-05","こどもの日"],
+    ["2009-05-06","振替休日"],
+    ["2009-07-20","海の日"],
+    ["2009-09-21","敬老の日"],
+    ["2009-09-22","国民の休日"],
+    ["2009-09-23","秋分の日"],
+    ["2009-10-12","体育の日"],
+    ["2009-11-03","文化の日"],
+    ["2009-11-23","勤労感謝の日"],
+    ["2009-12-23","天皇誕生日"],
+    ["2010-01-01","元日"],
+    ["2010-01-11","成人の日"],
+    ["2010-02-11","建国記念の日"],
+    ["2010-03-21","春分の日"],
+    ["2010-03-22","振替休日"],
+    ["2010-04-29","昭和の日"],
+    ["2010-05-03","憲法記念日"],
+    ["2010-05-04","みどりの日"],
+    ["2010-05-05","こどもの日"],
+    ["2010-07-19","海の日"],
+    ["2010-09-20","敬老の日"],
+    ["2010-09-23","秋分の日"],
+    ["2010-10-11","体育の日"],
+    ["2010-11-03","文化の日"],
+    ["2010-11-23","勤労感謝の日"],
+    ["2010-12-23","天皇誕生日"],
+    ["2011-01-01","元日"],
+    ["2011-01-10","成人の日"],
+    ["2011-02-11","建国記念の日"],
+    ["2011-03-21","春分の日"],
+    ["2011-04-29","昭和の日"],
+    ["2011-05-03","憲法記念日"],
+    ["2011-05-04","みどりの日"],
+    ["2011-05-05","こどもの日"],
+    ["2011-07-18","海の日"],
+    ["2011-09-19","敬老の日"],
+    ["2011-09-23","秋分の日"],
+    ["2011-10-10","体育の日"],
+    ["2011-11-03","文化の日"],
+    ["2011-11-23","勤労感謝の日"],
+    ["2011-12-23","天皇誕生日"],
+    ["2012-01-01","元日"],
+    ["2012-01-02","振替休日"],
+    ["2012-01-09","成人の日"],
+    ["2012-02-11","建国記念の日"],
+    ["2012-03-20","春分の日"],
+    ["2012-04-29","昭和の日"],
+    ["2012-04-30","振替休日"],
+    ["2012-05-03","憲法記念日"],
+    ["2012-05-04","みどりの日"],
+    ["2012-05-05","こどもの日"],
+    ["2012-07-16","海の日"],
+    ["2012-09-17","敬老の日"],
+    ["2012-09-22","秋分の日"],
+    ["2012-10-08","体育の日"],
+    ["2012-11-03","文化の日"],
+    ["2012-11-23","勤労感謝の日"],
+    ["2012-12-23","天皇誕生日"],
+    ["2012-12-24","振替休日"],
+    ["2013-01-01","元日"],
+    ["2013-01-14","成人の日"],
+    ["2013-02-11","建国記念の日"],
+    ["2013-03-20","春分の日"],
+    ["2013-04-29","昭和の日"],
+    ["2013-05-03","憲法記念日"],
+    ["2013-05-04","みどりの日"],
+    ["2013-05-05","こどもの日"],
+    ["2013-05-06","振替休日"],
+    ["2013-07-15","海の日"],
+    ["2013-09-16","敬老の日"],
+    ["2013-09-23","秋分の日"],
+    ["2013-10-14","体育の日"],
+    ["2013-11-03","文化の日"],
+    ["2013-11-04","振替休日"],
+    ["2013-11-23","勤労感謝の日"],
+    ["2013-12-23","天皇誕生日"],
+    ["2014-01-01","元日"],
+    ["2014-01-13","成人の日"],
+    ["2014-02-11","建国記念の日"],
+    ["2014-03-21","春分の日"],
+    ["2014-04-29","昭和の日"],
+    ["2014-05-03","憲法記念日"],
+    ["2014-05-04","みどりの日"],
+    ["2014-05-05","こどもの日"],
+    ["2014-05-06","振替休日"],
+    ["2014-07-21","海の日"],
+    ["2014-09-15","敬老の日"],
+    ["2014-09-23","秋分の日"],
+    ["2014-10-13","体育の日"],
+    ["2014-11-03","文化の日"],
+    ["2014-11-23","勤労感謝の日"],
+    ["2014-11-24","振替休日"],
+    ["2014-12-23","天皇誕生日"],
+    ["2015-01-01","元日"],
+    ["2015-01-12","成人の日"],
+    ["2015-02-11","建国記念の日"],
+    ["2015-03-21","春分の日"],
+    ["2015-04-29","昭和の日"],
+    ["2015-05-03","憲法記念日"],
+    ["2015-05-04","みどりの日"],
+    ["2015-05-05","こどもの日"],
+    ["2015-05-06","振替休日"],
+    ["2015-07-20","海の日"],
+    ["2015-09-21","敬老の日"],
+    ["2015-09-22","国民の休日"],
+    ["2015-09-23","秋分の日"],
+    ["2015-10-12","体育の日"],
+    ["2015-11-03","文化の日"],
+    ["2015-11-23","勤労感謝の日"],
+    ["2015-12-23","天皇誕生日"],
+    ["2016-01-01","元日"],
+    ["2016-01-11","成人の日"],
+    ["2016-02-11","建国記念の日"],
+    ["2016-03-20","春分の日"],
+    ["2016-03-21","振替休日"],
+    ["2016-04-29","昭和の日"],
+    ["2016-05-03","憲法記念日"],
+    ["2016-05-04","みどりの日"],
+    ["2016-05-05","こどもの日"],
+    ["2016-07-18","海の日"],
+    ["2016-09-19","敬老の日"],
+    ["2016-09-22","秋分の日"],
+    ["2016-10-10","体育の日"],
+    ["2016-11-03","文化の日"],
+    ["2016-11-23","勤労感謝の日"],
+    ["2016-12-23","天皇誕生日"],
+    ["2017-01-01","元日"],
+    ["2017-01-02","振替休日"],
+    ["2017-01-09","成人の日"],
+    ["2017-02-11","建国記念の日"],
+    ["2017-03-20","春分の日"],
+    ["2017-04-29","昭和の日"],
+    ["2017-05-03","憲法記念日"],
+    ["2017-05-04","みどりの日"],
+    ["2017-05-05","こどもの日"],
+    ["2017-07-17","海の日"],
+    ["2017-09-18","敬老の日"],
+    ["2017-09-23","秋分の日"],
+    ["2017-10-09","体育の日"],
+    ["2017-11-03","文化の日"],
+    ["2017-11-23","勤労感謝の日"],
+    ["2017-12-23","天皇誕生日"],
+    ["2018-01-01","元日"],
+    ["2018-01-08","成人の日"],
+    ["2018-02-11","建国記念の日"],
+    ["2018-02-12","振替休日"],
+    ["2018-03-21","春分の日"],
+    ["2018-04-29","昭和の日"],
+    ["2018-04-30","振替休日"],
+    ["2018-05-03","憲法記念日"],
+    ["2018-05-04","みどりの日"],
+    ["2018-05-05","こどもの日"],
+    ["2018-07-16","海の日"],
+    ["2018-09-17","敬老の日"],
+    ["2018-09-23","秋分の日"],
+    ["2018-09-24","振替休日"],
+    ["2018-10-08","体育の日"],
+    ["2018-11-03","文化の日"],
+    ["2018-11-23","勤労感謝の日"],
+    ["2018-12-23","天皇誕生日"],
+    ["2018-12-24","振替休日"],
+    ["2019-01-01","元日"],
+    ["2019-01-14","成人の日"],
+    ["2019-02-11","建国記念の日"],
+    ["2019-03-21","春分の日"],
+    ["2019-04-29","昭和の日"],
+    ["2019-05-03","憲法記念日"],
+    ["2019-05-04","みどりの日"],
+    ["2019-05-05","こどもの日"],
+    ["2019-05-06","振替休日"],
+    ["2019-07-15","海の日"],
+    ["2019-09-16","敬老の日"],
+    ["2019-09-23","秋分の日"],
+    ["2019-10-14","体育の日"],
+    ["2019-11-03","文化の日"],
+    ["2019-11-04","振替休日"],
+    ["2019-11-23","勤労感謝の日"],
+    ["2019-12-23","天皇誕生日"],
+    ["2020-01-01","元日"],
+    ["2020-01-13","成人の日"],
+    ["2020-02-11","建国記念の日"],
+    ["2020-03-20","春分の日"],
+    ["2020-04-29","昭和の日"],
+    ["2020-05-03","憲法記念日"],
+    ["2020-05-04","みどりの日"],
+    ["2020-05-05","こどもの日"],
+    ["2020-05-06","振替休日"],
+    ["2020-07-20","海の日"],
+    ["2020-09-21","敬老の日"],
+    ["2020-09-22","秋分の日"],
+    ["2020-10-12","体育の日"],
+    ["2020-11-03","文化の日"],
+    ["2020-11-23","勤労感謝の日"],
+    ["2020-12-23","天皇誕生日"],
+    ["2021-01-01","元日"],
+    ["2021-01-11","成人の日"],
+    ["2021-02-11","建国記念の日"],
+    ["2021-03-20","春分の日"],
+    ["2021-04-29","昭和の日"],
+    ["2021-05-03","憲法記念日"],
+    ["2021-05-04","みどりの日"],
+    ["2021-05-05","こどもの日"],
+    ["2021-07-19","海の日"],
+    ["2021-09-20","敬老の日"],
+    ["2021-09-23","秋分の日"],
+    ["2021-10-11","体育の日"],
+    ["2021-11-03","文化の日"],
+    ["2021-11-23","勤労感謝の日"],
+    ["2021-12-23","天皇誕生日"],
+    ["2022-01-01","元日"],
+    ["2022-01-10","成人の日"],
+    ["2022-02-11","建国記念の日"],
+    ["2022-03-21","春分の日"],
+    ["2022-04-29","昭和の日"],
+    ["2022-05-03","憲法記念日"],
+    ["2022-05-04","みどりの日"],
+    ["2022-05-05","こどもの日"],
+    ["2022-07-18","海の日"],
+    ["2022-09-19","敬老の日"],
+    ["2022-09-23","秋分の日"],
+    ["2022-10-10","体育の日"],
+    ["2022-11-03","文化の日"],
+    ["2022-11-23","勤労感謝の日"],
+    ["2022-12-23","天皇誕生日"],
+    ["2023-01-01","元日"],
+    ["2023-01-02","振替休日"],
+    ["2023-01-09","成人の日"],
+    ["2023-02-11","建国記念の日"],
+    ["2023-03-21","春分の日"],
+    ["2023-04-29","昭和の日"],
+    ["2023-05-03","憲法記念日"],
+    ["2023-05-04","みどりの日"],
+    ["2023-05-05","こどもの日"],
+    ["2023-07-17","海の日"],
+    ["2023-09-18","敬老の日"],
+    ["2023-09-23","秋分の日"],
+    ["2023-10-09","体育の日"],
+    ["2023-11-03","文化の日"],
+    ["2023-11-23","勤労感謝の日"],
+    ["2023-12-23","天皇誕生日"],
+    ["2024-01-01","元日"],
+    ["2024-01-08","成人の日"],
+    ["2024-02-11","建国記念の日"],
+    ["2024-02-12","振替休日"],
+    ["2024-03-20","春分の日"],
+    ["2024-04-29","昭和の日"],
+    ["2024-05-03","憲法記念日"],
+    ["2024-05-04","みどりの日"],
+    ["2024-05-05","こどもの日"],
+    ["2024-05-06","振替休日"],
+    ["2024-07-15","海の日"],
+    ["2024-09-16","敬老の日"],
+    ["2024-09-22","秋分の日"],
+    ["2024-09-23","振替休日"],
+    ["2024-10-14","体育の日"],
+    ["2024-11-03","文化の日"],
+    ["2024-11-04","振替休日"],
+    ["2024-11-23","勤労感謝の日"],
+    ["2024-12-23","天皇誕生日"],
+    ["2025-01-01","元日"],
+    ["2025-01-13","成人の日"],
+    ["2025-02-11","建国記念の日"],
+    ["2025-03-20","春分の日"],
+    ["2025-04-29","昭和の日"],
+    ["2025-05-03","憲法記念日"],
+    ["2025-05-04","みどりの日"],
+    ["2025-05-05","こどもの日"],
+    ["2025-05-06","振替休日"],
+    ["2025-07-21","海の日"],
+    ["2025-09-15","敬老の日"],
+    ["2025-09-23","秋分の日"],
+    ["2025-10-13","体育の日"],
+    ["2025-11-03","文化の日"],
+    ["2025-11-23","勤労感謝の日"],
+    ["2025-11-24","振替休日"],
+    ["2025-12-23","天皇誕生日"],
+    ["2026-01-01","元日"],
+    ["2026-01-12","成人の日"],
+    ["2026-02-11","建国記念の日"],
+    ["2026-03-20","春分の日"],
+    ["2026-04-29","昭和の日"],
+    ["2026-05-03","憲法記念日"],
+    ["2026-05-04","みどりの日"],
+    ["2026-05-05","こどもの日"],
+    ["2026-05-06","振替休日"],
+    ["2026-07-20","海の日"],
+    ["2026-09-21","敬老の日"],
+    ["2026-09-22","国民の休日"],
+    ["2026-09-23","秋分の日"],
+    ["2026-10-12","体育の日"],
+    ["2026-11-03","文化の日"],
+    ["2026-11-23","勤労感謝の日"],
+    ["2026-12-23","天皇誕生日"],
+    ["2027-01-01","元日"],
+    ["2027-01-11","成人の日"],
+    ["2027-02-11","建国記念の日"],
+    ["2027-03-21","春分の日"],
+    ["2027-03-22","振替休日"],
+    ["2027-04-29","昭和の日"],
+    ["2027-05-03","憲法記念日"],
+    ["2027-05-04","みどりの日"],
+    ["2027-05-05","こどもの日"],
+    ["2027-07-19","海の日"],
+    ["2027-09-20","敬老の日"],
+    ["2027-09-23","秋分の日"],
+    ["2027-10-11","体育の日"],
+    ["2027-11-03","文化の日"],
+    ["2027-11-23","勤労感謝の日"],
+    ["2027-12-23","天皇誕生日"],
+    ["2028-01-01","元日"],
+    ["2028-01-10","成人の日"],
+    ["2028-02-11","建国記念の日"],
+    ["2028-03-20","春分の日"],
+    ["2028-04-29","昭和の日"],
+    ["2028-05-03","憲法記念日"],
+    ["2028-05-04","みどりの日"],
+    ["2028-05-05","こどもの日"],
+    ["2028-07-17","海の日"],
+    ["2028-09-18","敬老の日"],
+    ["2028-09-22","秋分の日"],
+    ["2028-10-09","体育の日"],
+    ["2028-11-03","文化の日"],
+    ["2028-11-23","勤労感謝の日"],
+    ["2028-12-23","天皇誕生日"],
+    ["2029-01-01","元日"],
+    ["2029-01-08","成人の日"],
+    ["2029-02-11","建国記念の日"],
+    ["2029-02-12","振替休日"],
+    ["2029-03-20","春分の日"],
+    ["2029-04-29","昭和の日"],
+    ["2029-04-30","振替休日"],
+    ["2029-05-03","憲法記念日"],
+    ["2029-05-04","みどりの日"],
+    ["2029-05-05","こどもの日"],
+    ["2029-07-16","海の日"],
+    ["2029-09-17","敬老の日"],
+    ["2029-09-23","秋分の日"],
+    ["2029-09-24","振替休日"],
+    ["2029-10-08","体育の日"],
+    ["2029-11-03","文化の日"],
+    ["2029-11-23","勤労感謝の日"],
+    ["2029-12-23","天皇誕生日"],
+    ["2029-12-24","振替休日"],
+    ["2030-01-01","元日"],
+    ["2030-01-14","成人の日"],
+    ["2030-02-11","建国記念の日"],
+    ["2030-03-20","春分の日"],
+    ["2030-04-29","昭和の日"],
+    ["2030-05-03","憲法記念日"],
+    ["2030-05-04","みどりの日"],
+    ["2030-05-05","こどもの日"],
+    ["2030-05-06","振替休日"],
+    ["2030-07-15","海の日"],
+    ["2030-09-16","敬老の日"],
+    ["2030-09-23","秋分の日"],
+    ["2030-10-14","体育の日"],
+    ["2030-11-03","文化の日"],
+    ["2030-11-04","振替休日"],
+    ["2030-11-23","勤労感謝の日"],
+    ["2030-12-23","天皇誕生日"],
+    ["2031-01-01","元日"],
+    ["2031-01-13","成人の日"],
+    ["2031-02-11","建国記念の日"],
+    ["2031-03-21","春分の日"],
+    ["2031-04-29","昭和の日"],
+    ["2031-05-03","憲法記念日"],
+    ["2031-05-04","みどりの日"],
+    ["2031-05-05","こどもの日"],
+    ["2031-05-06","振替休日"],
+    ["2031-07-21","海の日"],
+    ["2031-09-15","敬老の日"],
+    ["2031-09-23","秋分の日"],
+    ["2031-10-13","体育の日"],
+    ["2031-11-03","文化の日"],
+    ["2031-11-23","勤労感謝の日"],
+    ["2031-11-24","振替休日"],
+    ["2031-12-23","天皇誕生日"],
+    ["2032-01-01","元日"],
+    ["2032-01-12","成人の日"],
+    ["2032-02-11","建国記念の日"],
+    ["2032-03-20","春分の日"],
+    ["2032-04-29","昭和の日"],
+    ["2032-05-03","憲法記念日"],
+    ["2032-05-04","みどりの日"],
+    ["2032-05-05","こどもの日"],
+    ["2032-07-19","海の日"],
+    ["2032-09-20","敬老の日"],
+    ["2032-09-21","国民の休日"],
+    ["2032-09-22","秋分の日"],
+    ["2032-10-11","体育の日"],
+    ["2032-11-03","文化の日"],
+    ["2032-11-23","勤労感謝の日"],
+    ["2032-12-23","天皇誕生日"],
+    ["2033-01-01","元日"],
+    ["2033-01-10","成人の日"],
+    ["2033-02-11","建国記念の日"],
+    ["2033-03-20","春分の日"],
+    ["2033-03-21","振替休日"],
+    ["2033-04-29","昭和の日"],
+    ["2033-05-03","憲法記念日"],
+    ["2033-05-04","みどりの日"],
+    ["2033-05-05","こどもの日"],
+    ["2033-07-18","海の日"],
+    ["2033-09-19","敬老の日"],
+    ["2033-09-23","秋分の日"],
+    ["2033-10-10","体育の日"],
+    ["2033-11-03","文化の日"],
+    ["2033-11-23","勤労感謝の日"],
+    ["2033-12-23","天皇誕生日"],
+    ["2034-01-01","元日"],
+    ["2034-01-02","振替休日"],
+    ["2034-01-09","成人の日"],
+    ["2034-02-11","建国記念の日"],
+    ["2034-03-20","春分の日"],
+    ["2034-04-29","昭和の日"],
+    ["2034-05-03","憲法記念日"],
+    ["2034-05-04","みどりの日"],
+    ["2034-05-05","こどもの日"],
+    ["2034-07-17","海の日"],
+    ["2034-09-18","敬老の日"],
+    ["2034-09-23","秋分の日"],
+    ["2034-10-09","体育の日"],
+    ["2034-11-03","文化の日"],
+    ["2034-11-23","勤労感謝の日"],
+    ["2034-12-23","天皇誕生日"],
+    ["2035-01-01","元日"],
+    ["2035-01-08","成人の日"],
+    ["2035-02-11","建国記念の日"],
+    ["2035-02-12","振替休日"],
+    ["2035-03-21","春分の日"],
+    ["2035-04-29","昭和の日"],
+    ["2035-04-30","振替休日"],
+    ["2035-05-03","憲法記念日"],
+    ["2035-05-04","みどりの日"],
+    ["2035-05-05","こどもの日"],
+    ["2035-07-16","海の日"],
+    ["2035-09-17","敬老の日"],
+    ["2035-09-23","秋分の日"],
+    ["2035-09-24","振替休日"],
+    ["2035-10-08","体育の日"],
+    ["2035-11-03","文化の日"],
+    ["2035-11-23","勤労感謝の日"],
+    ["2035-12-23","天皇誕生日"],
+    ["2035-12-24","振替休日"],
+    ["2036-01-01","元日"],
+    ["2036-01-14","成人の日"],
+    ["2036-02-11","建国記念の日"],
+    ["2036-03-20","春分の日"],
+    ["2036-04-29","昭和の日"],
+    ["2036-05-03","憲法記念日"],
+    ["2036-05-04","みどりの日"],
+    ["2036-05-05","こどもの日"],
+    ["2036-05-06","振替休日"],
+    ["2036-07-21","海の日"],
+    ["2036-09-15","敬老の日"],
+    ["2036-09-22","秋分の日"],
+    ["2036-10-13","体育の日"],
+    ["2036-11-03","文化の日"],
+    ["2036-11-23","勤労感謝の日"],
+    ["2036-11-24","振替休日"],
+    ["2036-12-23","天皇誕生日"],
+    ["2037-01-01","元日"],
+    ["2037-01-12","成人の日"],
+    ["2037-02-11","建国記念の日"],
+    ["2037-03-20","春分の日"],
+    ["2037-04-29","昭和の日"],
+    ["2037-05-03","憲法記念日"],
+    ["2037-05-04","みどりの日"],
+    ["2037-05-05","こどもの日"],
+    ["2037-05-06","振替休日"],
+    ["2037-07-20","海の日"],
+    ["2037-09-21","敬老の日"],
+    ["2037-09-22","国民の休日"],
+    ["2037-09-23","秋分の日"],
+    ["2037-10-12","体育の日"],
+    ["2037-11-03","文化の日"],
+    ["2037-11-23","勤労感謝の日"],
+    ["2037-12-23","天皇誕生日"],
+    ["2038-01-01","元日"],
+    ["2038-01-11","成人の日"],
+    ["2038-02-11","建国記念の日"],
+    ["2038-03-20","春分の日"],
+    ["2038-04-29","昭和の日"],
+    ["2038-05-03","憲法記念日"],
+    ["2038-05-04","みどりの日"],
+    ["2038-05-05","こどもの日"],
+    ["2038-07-19","海の日"],
+    ["2038-09-20","敬老の日"],
+    ["2038-09-23","秋分の日"],
+    ["2038-10-11","体育の日"],
+    ["2038-11-03","文化の日"],
+    ["2038-11-23","勤労感謝の日"],
+    ["2038-12-23","天皇誕生日"],
+    ["2039-01-01","元日"],
+    ["2039-01-10","成人の日"],
+    ["2039-02-11","建国記念の日"],
+    ["2039-03-21","春分の日"],
+    ["2039-04-29","昭和の日"],
+    ["2039-05-03","憲法記念日"],
+    ["2039-05-04","みどりの日"],
+    ["2039-05-05","こどもの日"],
+    ["2039-07-18","海の日"],
+    ["2039-09-19","敬老の日"],
+    ["2039-09-23","秋分の日"],
+    ["2039-10-10","体育の日"],
+    ["2039-11-03","文化の日"],
+    ["2039-11-23","勤労感謝の日"],
+    ["2039-12-23","天皇誕生日"],
+    ["2040-01-01","元日"],
+    ["2040-01-02","振替休日"],
+    ["2040-01-09","成人の日"],
+    ["2040-02-11","建国記念の日"],
+    ["2040-03-20","春分の日"],
+    ["2040-04-29","昭和の日"],
+    ["2040-04-30","振替休日"],
+    ["2040-05-03","憲法記念日"],
+    ["2040-05-04","みどりの日"],
+    ["2040-05-05","こどもの日"],
+    ["2040-07-16","海の日"],
+    ["2040-09-17","敬老の日"],
+    ["2040-09-22","秋分の日"],
+    ["2040-10-08","体育の日"],
+    ["2040-11-03","文化の日"],
+    ["2040-11-23","勤労感謝の日"],
+    ["2040-12-23","天皇誕生日"],
+    ["2040-12-24","振替休日"],
+    ["2041-01-01","元日"],
+    ["2041-01-14","成人の日"],
+    ["2041-02-11","建国記念の日"],
+    ["2041-03-20","春分の日"],
+    ["2041-04-29","昭和の日"],
+    ["2041-05-03","憲法記念日"],
+    ["2041-05-04","みどりの日"],
+    ["2041-05-05","こどもの日"],
+    ["2041-05-06","振替休日"],
+    ["2041-07-15","海の日"],
+    ["2041-09-16","敬老の日"],
+    ["2041-09-23","秋分の日"],
+    ["2041-10-14","体育の日"],
+    ["2041-11-03","文化の日"],
+    ["2041-11-04","振替休日"],
+    ["2041-11-23","勤労感謝の日"],
+    ["2041-12-23","天皇誕生日"],
+    ["2042-01-01","元日"],
+    ["2042-01-13","成人の日"],
+    ["2042-02-11","建国記念の日"],
+    ["2042-03-20","春分の日"],
+    ["2042-04-29","昭和の日"],
+    ["2042-05-03","憲法記念日"],
+    ["2042-05-04","みどりの日"],
+    ["2042-05-05","こどもの日"],
+    ["2042-05-06","振替休日"],
+    ["2042-07-21","海の日"],
+    ["2042-09-15","敬老の日"],
+    ["2042-09-23","秋分の日"],
+    ["2042-10-13","体育の日"],
+    ["2042-11-03","文化の日"],
+    ["2042-11-23","勤労感謝の日"],
+    ["2042-11-24","振替休日"],
+    ["2042-12-23","天皇誕生日"],
+    ["2043-01-01","元日"],
+    ["2043-01-12","成人の日"],
+    ["2043-02-11","建国記念の日"],
+    ["2043-03-21","春分の日"],
+    ["2043-04-29","昭和の日"],
+    ["2043-05-03","憲法記念日"],
+    ["2043-05-04","みどりの日"],
+    ["2043-05-05","こどもの日"],
+    ["2043-05-06","振替休日"],
+    ["2043-07-20","海の日"],
+    ["2043-09-21","敬老の日"],
+    ["2043-09-22","国民の休日"],
+    ["2043-09-23","秋分の日"],
+    ["2043-10-12","体育の日"],
+    ["2043-11-03","文化の日"],
+    ["2043-11-23","勤労感謝の日"],
+    ["2043-12-23","天皇誕生日"],
+    ["2044-01-01","元日"],
+    ["2044-01-11","成人の日"],
+    ["2044-02-11","建国記念の日"],
+    ["2044-03-20","春分の日"],
+    ["2044-03-21","振替休日"],
+    ["2044-04-29","昭和の日"],
+    ["2044-05-03","憲法記念日"],
+    ["2044-05-04","みどりの日"],
+    ["2044-05-05","こどもの日"],
+    ["2044-07-18","海の日"],
+    ["2044-09-19","敬老の日"],
+    ["2044-09-22","秋分の日"],
+    ["2044-10-10","体育の日"],
+    ["2044-11-03","文化の日"],
+    ["2044-11-23","勤労感謝の日"],
+    ["2044-12-23","天皇誕生日"],
+    ["2045-01-01","元日"],
+    ["2045-01-02","振替休日"],
+    ["2045-01-09","成人の日"],
+    ["2045-02-11","建国記念の日"],
+    ["2045-03-20","春分の日"],
+    ["2045-04-29","昭和の日"],
+    ["2045-05-03","憲法記念日"],
+    ["2045-05-04","みどりの日"],
+    ["2045-05-05","こどもの日"],
+    ["2045-07-17","海の日"],
+    ["2045-09-18","敬老の日"],
+    ["2045-09-22","秋分の日"],
+    ["2045-10-09","体育の日"],
+    ["2045-11-03","文化の日"],
+    ["2045-11-23","勤労感謝の日"],
+    ["2045-12-23","天皇誕生日"],
+    ["2046-01-01","元日"],
+    ["2046-01-08","成人の日"],
+    ["2046-02-11","建国記念の日"],
+    ["2046-02-12","振替休日"],
+    ["2046-03-20","春分の日"],
+    ["2046-04-29","昭和の日"],
+    ["2046-04-30","振替休日"],
+    ["2046-05-03","憲法記念日"],
+    ["2046-05-04","みどりの日"],
+    ["2046-05-05","こどもの日"],
+    ["2046-07-16","海の日"],
+    ["2046-09-17","敬老の日"],
+    ["2046-09-23","秋分の日"],
+    ["2046-09-24","振替休日"],
+    ["2046-10-08","体育の日"],
+    ["2046-11-03","文化の日"],
+    ["2046-11-23","勤労感謝の日"],
+    ["2046-12-23","天皇誕生日"],
+    ["2046-12-24","振替休日"],
+    ["2047-01-01","元日"],
+    ["2047-01-14","成人の日"],
+    ["2047-02-11","建国記念の日"],
+    ["2047-03-21","春分の日"],
+    ["2047-04-29","昭和の日"],
+    ["2047-05-03","憲法記念日"],
+    ["2047-05-04","みどりの日"],
+    ["2047-05-05","こどもの日"],
+    ["2047-05-06","振替休日"],
+    ["2047-07-15","海の日"],
+    ["2047-09-16","敬老の日"],
+    ["2047-09-23","秋分の日"],
+    ["2047-10-14","体育の日"],
+    ["2047-11-03","文化の日"],
+    ["2047-11-04","振替休日"],
+    ["2047-11-23","勤労感謝の日"],
+    ["2047-12-23","天皇誕生日"],
+    ["2048-01-01","元日"],
+    ["2048-01-13","成人の日"],
+    ["2048-02-11","建国記念の日"],
+    ["2048-03-20","春分の日"],
+    ["2048-04-29","昭和の日"],
+    ["2048-05-03","憲法記念日"],
+    ["2048-05-04","みどりの日"],
+    ["2048-05-05","こどもの日"],
+    ["2048-05-06","振替休日"],
+    ["2048-07-20","海の日"],
+    ["2048-09-21","敬老の日"],
+    ["2048-09-22","秋分の日"],
+    ["2048-10-12","体育の日"],
+    ["2048-11-03","文化の日"],
+    ["2048-11-23","勤労感謝の日"],
+    ["2048-12-23","天皇誕生日"],
+    ["2049-01-01","元日"],
+    ["2049-01-11","成人の日"],
+    ["2049-02-11","建国記念の日"],
+    ["2049-03-20","春分の日"],
+    ["2049-04-29","昭和の日"],
+    ["2049-05-03","憲法記念日"],
+    ["2049-05-04","みどりの日"],
+    ["2049-05-05","こどもの日"],
+    ["2049-07-19","海の日"],
+    ["2049-09-20","敬老の日"],
+    ["2049-09-21","国民の休日"],
+    ["2049-09-22","秋分の日"],
+    ["2049-10-11","体育の日"],
+    ["2049-11-03","文化の日"],
+    ["2049-11-23","勤労感謝の日"],
+    ["2049-12-23","天皇誕生日"],
+    ["2050-01-01","元日"],
+    ["2050-01-10","成人の日"],
+    ["2050-02-11","建国記念の日"],
+    ["2050-03-20","春分の日"],
+    ["2050-03-21","振替休日"],
+    ["2050-04-29","昭和の日"],
+    ["2050-05-03","憲法記念日"],
+    ["2050-05-04","みどりの日"],
+    ["2050-05-05","こどもの日"],
+    ["2050-07-18","海の日"],
+    ["2050-09-19","敬老の日"],
+    ["2050-09-23","秋分の日"],
+    ["2050-10-10","体育の日"],
+    ["2050-11-03","文化の日"],
+    ["2050-11-23","勤労感謝の日"],
+    ["2050-12-23","天皇誕生日"],
   ]
-  HOLIDAYS = Hash[base_data.map {|h| [h[:date], OpenStruct.new(h)]}]
+  HOLIDAYS = Hash[base_holidays.map {|e| [(h = Holiday.new(*e)).date, h]}]
 end

--- a/test/test_holiday_jp.rb
+++ b/test/test_holiday_jp.rb
@@ -4,8 +4,12 @@ require 'helper'
 class TestHolidayJp < Test::Unit::TestCase
   should '#between return correct holidays' do
     holidays = HolidayJp.between(Date.new(2009, 1, 1), Date.new(2009, 1, 31))
-    assert_equal holidays[0].date, Date.new(2009, 1, 1)
-    assert_equal holidays[0].name, '元日'
+    new_year_day = holidays[0]
+    assert_equal new_year_day.date, Date.new(2009, 1, 1)
+    assert_equal new_year_day.name, '元日'
+    assert_equal new_year_day.name_en, "New Year's Day"
+    assert_equal new_year_day.week, '木'
+    assert_equal new_year_day.wday_name, '木'
     assert_equal holidays[1].date, Date.new(2009, 1, 12)
     assert_equal holidays[1].name, '成人の日'
     holidays = HolidayJp.between(Date.new(2008, 12, 23), Date.new(2009, 1, 12))


### PR DESCRIPTION
I think the file 7,000 lines to define holidays is too big to maintain.

---

にほんご:

1,200行ぐらいまで減らしましたが、そのためにHashで管理するのをやめてしまいました。
外部ファイルに追い出すとだいぶ遅くなってしまったので、文字列で並べてます。
ostructをやめたので、その分はちょっと(だけ)早くなってます。
