### PR TITLE
Accepts datable objects as arguments such as Time and DateTime

### DIFF
--- a/lib/holiday_jp/holidays.rb
+++ b/lib/holiday_jp/holidays.rb
@@ -14,12 +14,12 @@ module HolidayJp
 
     def between(start, last)
       holidays.find_all do |date, _holiday|
-        start <= date && date <= last
+        start.to_date <= date && date <= last.to_date
       end.map(&:last)
     end
 
     def holiday?(date)
-      holidays[date]
+      holidays[date.to_date]
     end
   end
 end

--- a/test/test_holiday_jp.rb
+++ b/test/test_holiday_jp.rb
@@ -19,9 +19,33 @@ class TestHolidayJp < Test::Unit::TestCase
     assert_equal holidays[2].date, Date.new(2009, 1, 12)
   end
 
+  def test_between_accepts_datetime
+    holidays = HolidayJp.between(DateTime.new(2008, 12, 23), DateTime.new(2009, 1, 12))
+    assert_equal holidays[0].date, Date.new(2008, 12, 23)
+    assert_equal holidays[1].date, Date.new(2009, 1, 1)
+    assert_equal holidays[2].date, Date.new(2009, 1, 12)
+  end
+
+  def test_between_accepts_time
+    holidays = HolidayJp.between(Time.new(2008, 12, 23), Time.new(2009, 1, 12))
+    assert_equal holidays[0].date, Date.new(2008, 12, 23)
+    assert_equal holidays[1].date, Date.new(2009, 1, 1)
+    assert_equal holidays[2].date, Date.new(2009, 1, 12)
+  end
+
   def test_holiday?
     assert HolidayJp.holiday?(Date.new(2011, 9, 19))
     assert !HolidayJp.holiday?(Date.new(2011, 9, 18))
+  end
+
+  def test_holiday_p_accepts_datetime
+    assert HolidayJp.holiday?(DateTime.new(2011, 9, 19))
+    assert !HolidayJp.holiday?(DateTime.new(2011, 9, 18))
+  end
+
+  def test_holiday_p_accepts_time
+    assert HolidayJp.holiday?(Time.new(2011, 9, 19))
+    assert !HolidayJp.holiday?(Time.new(2011, 9, 18))
   end
 
   def test_mountain_day_from_2016


### PR DESCRIPTION
`HolidayJp.holiday?` and `HolidayJp.between` only accept `Date` instance now.
But Ruby has other classes to treat date and time such as `DateTime` and `Time`, and we can convert them into `Date` by `to_date` method if `date` library is loaded.
So, I think `HolidayJp` should accepts objects which have `to_date` method.