### PR TITLE
Update allowed bundler version

### DIFF
--- a/holiday_jp.gemspec
+++ b/holiday_jp.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_development_dependency 'bundler', '~> 1.6'
+  s.add_development_dependency 'bundler', '< 3.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'test-unit', '3.0.9'
 end


### PR DESCRIPTION
Allow bundler version `2.x`. Because bundler version of Travis CI (Ruby 2.3.1, 2.4.1) is 2.1.2.