### PR TITLE
update test-unit for Ruby 3.0

### DIFF
--- a/holiday_jp.gemspec
+++ b/holiday_jp.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler', '< 3.0'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'test-unit', '3.0.9'
+  s.add_development_dependency 'test-unit', '< 4.0'
 end


### PR DESCRIPTION
test/unit 3.3 or higher supports Ruby 3.0 :rocket:

It was done with the following commit.

https://github.com/test-unit/test-unit/commit/7c93699e92ebb05fe0d68e2df1a99774a721aa92
