### PR TITLE
Adds support for Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,10 @@ jobs:
         include:
           - ruby-version: '3.0'
             experimental: true
+          - ruby-version: '3.1'
+            experimental: true
     continue-on-error: ${{ matrix.experimental }}
-      
+
     steps:
       - uses: ruby/setup-ruby@v1
         with:

--- a/lib/holiday_jp/holidays.rb
+++ b/lib/holiday_jp/holidays.rb
@@ -6,7 +6,13 @@ module HolidayJp
 
     def initialize
       @holidays = {}
-      yaml = YAML.load_file(File.expand_path("../../../holidays.yml", __FILE__))
+      yaml = {}
+      file = File.expand_path("../../../holidays.yml", __FILE__)
+      if YAML.respond_to?(:unsafe_load_file)
+        yaml = YAML.unsafe_load_file(file)
+      else
+        yaml = YAML.load_file(file)
+      end
       yaml.map do |key, value|
         @holidays[key] = Holiday.new(key, value)
       end

--- a/test/test_holiday_jp_yaml.rb
+++ b/test/test_holiday_jp_yaml.rb
@@ -5,11 +5,23 @@ require 'yaml'
 
 class TestHolidayJpYaml < Test::Unit::TestCase
   def test_yaml
-    yaml = YAML.load_file(File.expand_path('../../holidays.yml', __FILE__))
+    yaml = {}
+    file = File.expand_path("../../holidays.yml", __FILE__)
+    if YAML.respond_to?(:unsafe_load_file)
+      yaml = YAML.unsafe_load_file(file)
+    else
+      yaml = YAML.load_file(file)
+    end
+    holiday_jp_yaml = {}
     uri = URI.parse('https://raw.githubusercontent.com/holiday-jp/holiday_jp/v0.x/holidays.yml')
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
-    holiday_jp_yaml = YAML.load(http.get(uri.request_uri).body)
+    response_body = http.get(uri.request_uri).body
+    if YAML.respond_to?(:unsafe_load)
+      holiday_jp_yaml = YAML.unsafe_load(response_body)
+    else
+      holiday_jp_yaml = YAML.load(response_body)
+    end
     yaml.map do |date, name|
       assert_equal holiday_jp_yaml[date], name
     end


### PR DESCRIPTION
Ruby 3.1 ships with Psych 4.0.3 which makes `YAML.load_file` defaults to safe mode (ruby/psych#487).
This causes error on parsing `holidays.yml`.