### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/holiday_jp.gemspec
+++ b/holiday_jp.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version     = HolidayJp::VERSION
   s.authors     = ['Masaki Komagata']
   s.email       = ['komagata@gmail.com']
-  s.homepage    = 'http://github.com/komagata/holiday_jp'
+  s.homepage    = 'https://github.com/komagata/holiday_jp'
   s.summary     = 'Japanese Holidays.'
   s.description = 'Japanese Holidays from 1970 to 2050.'
 


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage http://rubygems.org/gems/holiday_jp via  some tools or APIs that use the gem's metadata, such as gem-src.