### PR TITLE
Ruby 3.0 and 3.1 are no longer experimental

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.4', '2.5', '2.6', '2.7']
+        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
         experimental: [false]
         include:
-          - ruby-version: '3.0'
-            experimental: true
-          - ruby-version: '3.1'
+          - ruby-version: 'ruby-head'
             experimental: true
     continue-on-error: ${{ matrix.experimental }}
 


### PR DESCRIPTION
Ruby 3.0 and 3.1 are production ready, and thus should better not be treated as experimental rubies IMO.

So here's a patch that requires these versions to always pass, and adds currently unstable 3.2.0-dev as an experimental version instead.