### PR TITLE
Change Ruby support version from 1.9.3+ to 2.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ HolidayJp.holiday?(Date.new(2016, 8 ,11)) # true
 ```
 
 ## Supported Ruby Version
-Ruby 1.9.3+
+Ruby 2.4+
 
 ## Installation
 

--- a/holiday_jp.gemspec
+++ b/holiday_jp.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'holiday_jp/version'
 

--- a/lib/holiday_jp/holiday.rb
+++ b/lib/holiday_jp/holiday.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require "date"
 
 module HolidayJp

--- a/test/test_holiday_jp.rb
+++ b/test/test_holiday_jp.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require 'test/unit'
 require File.expand_path('../../lib/holiday_jp', __FILE__)
 

--- a/test/test_holiday_jp_yaml.rb
+++ b/test/test_holiday_jp_yaml.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require 'test/unit'
 require 'net/http'
 require 'yaml'


### PR DESCRIPTION
Change the supported Ruby version according to the Ruby version confirmed by CI.
And Removed the Magic Comment for encoding.
Because the default encoding has changed to UTF-8 since Ruby 2.0.